### PR TITLE
feat: guard MCP SQL execution in pi

### DIFF
--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -1,50 +1,4 @@
 {
-  "effortLevel": "high",
-  "enabledPlugins": {},
-  "hooks": {
-    "PreToolUse": [
-      {
-        "hooks": [
-          {
-            "command": "$HOME/.claude/hooks/guard.sh",
-            "type": "command"
-          }
-        ],
-        "matcher": "Bash|Read|Edit|Write"
-      },
-      {
-        "hooks": [
-          {
-            "command": "$HOME/.claude/hooks/sql-guard.sh",
-            "type": "command"
-          }
-        ],
-        "matcher": "mcp__.*__(execute_sql|execute_query|query|explain_query)"
-      }
-    ],
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "command": "$HOME/.claude/hooks/morning-brief-nudge.sh",
-            "type": "command"
-          }
-        ],
-        "matcher": "startup|clear"
-      },
-      {
-        "hooks": [
-          {
-            "command": "bash '/Users/hssn/.claude/hooks/herdr-agent-state.sh' session",
-            "timeout": 10,
-            "type": "command"
-          }
-        ],
-        "matcher": "*"
-      }
-    ]
-  },
-  "model": "opus",
   "permissions": {
     "allow": [
       "Read(*)",
@@ -75,23 +29,55 @@
       "mcp__claude_ai_Google_Drive__search_files",
       "mcp__claude_ai_Google_Drive__get_file_metadata"
     ],
-    "ask": [
-      "Bash(node *)",
-      "Bash(npx *)",
-      "Bash(curl *)",
-      "Bash(pnpm install *)",
-      "Bash(pnpm exec *)",
-      "Bash(git push *)"
+    "deny": ["Bash(rm -rf *)", "Bash(git push --force *)", "Bash(git reset --hard *)", "Bash(git clean -f *)"],
+    "ask": ["Bash(node *)", "Bash(npx *)", "Bash(curl *)", "Bash(pnpm install *)", "Bash(pnpm exec *)", "Bash(git push *)"]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Read|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/guard.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__.*__(execute_sql|execute_query|query|explain_query)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/sql-guard.sh"
+          }
+        ]
+      }
     ],
-    "deny": [
-      "Bash(rm -rf *)",
-      "Bash(git push --force *)",
-      "Bash(git reset --hard *)",
-      "Bash(git clean -f *)"
+    "SessionStart": [
+      {
+        "matcher": "startup|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/morning-brief-nudge.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash '/Users/hssn/.claude/hooks/herdr-agent-state.sh' session",
+            "timeout": 10
+          }
+        ]
+      }
     ]
   },
   "statusLine": {
-    "command": "bash $HOME/.claude/statusline-command.sh",
-    "type": "command"
-  }
+    "type": "command",
+    "command": "bash $HOME/.claude/statusline-command.sh"
+  },
+  "effortLevel": "high"
 }

--- a/herdr/.config/herdr/config.toml
+++ b/herdr/.config/herdr/config.toml
@@ -3,5 +3,15 @@ onboarding = false
 [keys]
 prefix = "ctrl+s"
 
+[ui]
+agent_panel_scope = "all"
+show_agent_labels_on_pane_borders = true
+
 [theme]
 name = "tokyo-night"
+
+[ui.sound]
+enabled = false
+
+[ui.toast]
+delivery = "off"

--- a/pi/.pi/agent/extensions/guardrails.ts
+++ b/pi/.pi/agent/extensions/guardrails.ts
@@ -55,6 +55,13 @@ const secretPrefixes: string[] = [
 
 const secretBasenamePatterns: RegExp[] = [/^\.env(?:\..+|rc)?$/i, /\.pem$/i, /\.key$/i];
 
+const maxMcpSqlCost = 100_000;
+const writeSqlPattern =
+	/\b(INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|TRUNCATE|GRANT|REVOKE|MERGE|REPLACE|UPSERT|CALL|DO|COPY|VACUUM|REINDEX|REFRESH|COMMENT|LOCK|SET|COMMIT|ROLLBACK|SAVEPOINT|NOTIFY)\b/i;
+const largeTableSeqScanPatterns: RegExp[] = [/\bSeq Scan on (?:\w+\.)?t2060\b/i, /\bSeq Scan on (?:\w+\.)?t2061\b/i];
+
+const explainedMcpSql = new Map<string, { cost: number; explainedAt: number }>();
+
 function resolveToolPath(rawPath: string, cwd: string): string {
 	let path = rawPath.startsWith("@") ? rawPath.slice(1) : rawPath;
 	if (path === "~") path = homedir();
@@ -71,7 +78,115 @@ function isSecretPath(absolutePath: string): boolean {
 	return secretBasenamePatterns.some((pattern) => pattern.test(name));
 }
 
+type JsonRecord = Record<string, unknown>;
+type McpToolInput = JsonRecord & { tool?: string; args?: string };
+type McpSqlOperation = { kind: "explain" | "execute"; scope: string };
+type SqlSafety = { ok: true; normalisedSql: string } | { ok: false; reason: string };
 type Block = { block: true; reason: string };
+type ToolResultPatch = { content?: Array<{ type: "text"; text: string }>; details?: unknown; isError?: boolean };
+
+function isRecord(value: unknown): value is JsonRecord {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stripSqlComments(sql: string): string {
+	return sql.replace(/--[^\n\r]*/g, " ").replace(/\/\*[\s\S]*?\*\//g, " ");
+}
+
+function normaliseSql(sql: string): string {
+	return stripSqlComments(sql).replace(/;\s*$/g, "").replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function checkReadOnlySql(sql: string): SqlSafety {
+	const scan = stripSqlComments(sql).replace(/\s+/g, " ").trim();
+	const firstWord = scan.match(/[a-zA-Z]+/)?.[0].toUpperCase();
+	if (!firstWord) return { ok: false, reason: "SQL is empty" };
+	if (!new Set(["SELECT", "EXPLAIN", "SHOW", "VALUES", "WITH", "TABLE"]).has(firstWord)) {
+		return { ok: false, reason: "SQL must be read-only" };
+	}
+	if (/\bEXPLAIN\b[\s\S]*\bANALYZE\b/i.test(scan)) {
+		return { ok: false, reason: "EXPLAIN ANALYZE is blocked because it executes the query" };
+	}
+	if (writeSqlPattern.test(scan)) {
+		return { ok: false, reason: "SQL contains a write/DDL keyword" };
+	}
+	const normalisedSql = normaliseSql(sql);
+	if (!normalisedSql) return { ok: false, reason: "SQL is empty" };
+	return { ok: true, normalisedSql };
+}
+
+function parseMcpArgs(rawArgs: unknown): JsonRecord | undefined {
+	if (typeof rawArgs !== "string") return undefined;
+	try {
+		const parsed: unknown = JSON.parse(rawArgs);
+		return isRecord(parsed) ? parsed : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function extractSql(args: JsonRecord): string | undefined {
+	const candidate = args.sql ?? args.query ?? args.statement;
+	return typeof candidate === "string" ? candidate : undefined;
+}
+
+function requestsExplainAnalyse(args: JsonRecord): boolean {
+	return args.analyze === true || args.analyse === true;
+}
+
+function getMcpSqlOperation(tool: string): McpSqlOperation | undefined {
+	if (tool.endsWith("_explain_query")) return { kind: "explain", scope: tool.slice(0, -"_explain_query".length) };
+	if (tool.endsWith("_execute_sql")) return { kind: "execute", scope: tool.slice(0, -"_execute_sql".length) };
+	if (tool.endsWith("_execute_query")) return { kind: "execute", scope: tool.slice(0, -"_execute_query".length) };
+	if (tool.endsWith("_query")) return { kind: "execute", scope: tool.slice(0, -"_query".length) };
+	return undefined;
+}
+
+function explainedSqlKey(operation: McpSqlOperation, normalisedSql: string): string {
+	return `${operation.scope}\u0000${normalisedSql}`;
+}
+
+function getTextFromUnknown(value: unknown): string {
+	if (typeof value === "string") return value;
+	if (value === undefined || value === null) return "";
+	try {
+		return JSON.stringify(value) ?? "";
+	} catch {
+		return "";
+	}
+}
+
+function getToolResultText(content: ReadonlyArray<{ type?: string; text?: string }>, details: unknown): string {
+	const contentText = content
+		.map((item) => (item.type === "text" && typeof item.text === "string" ? item.text : ""))
+		.filter(Boolean)
+		.join("\n");
+	const detailsText = getTextFromUnknown(details);
+	return [contentText, detailsText].filter(Boolean).join("\n");
+}
+
+function extractMaxExplainCost(text: string): number | undefined {
+	const patterns: RegExp[] = [/\bCost:\s*([0-9]+(?:\.[0-9]+)?)\.\.([0-9]+(?:\.[0-9]+)?)/gi, /\bcost=([0-9]+(?:\.[0-9]+)?)\.\.([0-9]+(?:\.[0-9]+)?)/gi];
+	let maxCost: number | undefined;
+	for (const pattern of patterns) {
+		for (const match of text.matchAll(pattern)) {
+			const parsed = Number.parseFloat(match[2]);
+			if (Number.isFinite(parsed) && (maxCost === undefined || parsed > maxCost)) maxCost = parsed;
+		}
+	}
+	return maxCost;
+}
+
+function findBlockedSeqScan(text: string): string | undefined {
+	return largeTableSeqScanPatterns.find((pattern) => pattern.test(text))?.source;
+}
+
+function blockedSqlResult(message: string, existingText: string): ToolResultPatch {
+	return {
+		isError: true,
+		content: [{ type: "text" as const, text: [existingText, `Guardrail: ${message}`].filter(Boolean).join("\n\n") }],
+	};
+}
 
 export default function (pi: ExtensionAPI) {
 	pi.on("tool_call", async (event, ctx): Promise<Block | undefined> => {
@@ -97,6 +212,38 @@ export default function (pi: ExtensionAPI) {
 			return undefined;
 		}
 
+		if (isToolCallEventType<"mcp", McpToolInput>("mcp", event)) {
+			const tool = typeof event.input.tool === "string" ? event.input.tool : undefined;
+			if (!tool) return undefined;
+			const operation = getMcpSqlOperation(tool);
+			if (!operation) return undefined;
+
+			const args = parseMcpArgs(event.input.args);
+			if (!args) return { block: true, reason: `MCP SQL tool "${tool}" is missing parseable JSON args` };
+
+			const sql = extractSql(args);
+			if (!sql) return { block: true, reason: `MCP SQL tool "${tool}" is missing a sql/query/statement argument` };
+
+			const safety = checkReadOnlySql(sql);
+			if (!safety.ok) return { block: true, reason: safety.reason };
+
+			if (operation.kind === "explain") {
+				if (requestsExplainAnalyse(args)) {
+					return { block: true, reason: "MCP explain_query must use analyze=false" };
+				}
+				return undefined;
+			}
+
+			const explained = explainedMcpSql.get(explainedSqlKey(operation, safety.normalisedSql));
+			if (!explained) {
+				return { block: true, reason: `MCP execute_sql blocked: run ${operation.scope}_explain_query first` };
+			}
+			if (explained.cost > maxMcpSqlCost) {
+				return { block: true, reason: `MCP execute_sql blocked: explained cost ${explained.cost} exceeds ${maxMcpSqlCost}` };
+			}
+			return undefined;
+		}
+
 		if (isToolCallEventType("read", event)) {
 			const target = resolveToolPath(event.input.path, ctx.cwd);
 			if (isSecretPath(target)) {
@@ -115,6 +262,38 @@ export default function (pi: ExtensionAPI) {
 			return undefined;
 		}
 
+		return undefined;
+	});
+
+	pi.on("tool_result", (event): ToolResultPatch | undefined => {
+		if (event.toolName !== "mcp") return undefined;
+		const tool = typeof event.input.tool === "string" ? event.input.tool : undefined;
+		if (!tool) return undefined;
+		const operation = getMcpSqlOperation(tool);
+		if (!operation || operation.kind !== "explain") return undefined;
+
+		const args = parseMcpArgs(event.input.args);
+		if (!args) return undefined;
+		const sql = extractSql(args);
+		if (!sql) return undefined;
+		const safety = checkReadOnlySql(sql);
+		if (!safety.ok) return undefined;
+		if (event.isError) return undefined;
+
+		const text = getToolResultText(event.content, event.details);
+		const cost = extractMaxExplainCost(text);
+		if (cost === undefined) {
+			return blockedSqlResult("Could not parse EXPLAIN cost; execute_sql will remain blocked", text);
+		}
+		if (cost > maxMcpSqlCost) {
+			return blockedSqlResult(`EXPLAIN cost ${cost} exceeds ${maxMcpSqlCost}; execute_sql will remain blocked`, text);
+		}
+		const blockedSeqScan = findBlockedSeqScan(text);
+		if (blockedSeqScan) {
+			return blockedSqlResult(`EXPLAIN contains a blocked sequential scan (${blockedSeqScan}); execute_sql will remain blocked`, text);
+		}
+
+		explainedMcpSql.set(explainedSqlKey(operation, safety.normalisedSql), { cost, explainedAt: Date.now() });
 		return undefined;
 	});
 }


### PR DESCRIPTION
## Summary

- Add pi MCP SQL guardrails that require read-only SQL, block EXPLAIN ANALYZE, and require execute calls to be preceded by a matching EXPLAIN.
- Reject high-cost plans and sequential scans on known large tables before allowing MCP SQL execution.
- Update local Claude/herdr agent UI settings to reduce noise and keep agent panels visible.

## Test plan

- [x] `git diff origin/main..HEAD --check`
- [x] `jq empty claude/.claude/settings.json`
- [x] `herdr --help`
- [ ] Reload pi and exercise an MCP SQL explain/execute flow interactively
